### PR TITLE
Add modifier to return value so wat can be used within expressions

### DIFF
--- a/wat/inspection/inspection.py
+++ b/wat/inspection/inspection.py
@@ -360,7 +360,7 @@ Call {STYLE_YELLOW}wat.globals{RESET} to inspect {STYLE_YELLOW}globals(){RESET} 
         print(text)
 
     def _react_with(self, other: Any) -> Any:
-        ret = self._params.pop('ret')
+        ret = self._params.pop('ret', False)
         inspect(other, **self._params)
         if ret:
             return other

--- a/wat/inspection/inspection.py
+++ b/wat/inspection/inspection.py
@@ -351,6 +351,7 @@ Try {STYLE_YELLOW}wat / object{RESET} or {STYLE_YELLOW}wat.modifiers / object{RE
   {STYLE_GREEN}.code{RESET} to print source code of a function, method or class
   {STYLE_GREEN}.nodocs{RESET} to hide documentation for functions and classes
   {STYLE_GREEN}.all{RESET} to include all information
+  {STYLE_GREEN}.ret{RESET} to return {STYLE_YELLOW}object{RESET}
 Call {STYLE_YELLOW}wat.locals{RESET} or {STYLE_YELLOW}wat(){RESET} to inspect {STYLE_YELLOW}locals(){RESET} variables.
 Call {STYLE_YELLOW}wat.globals{RESET} to inspect {STYLE_YELLOW}globals(){RESET} variables.
 """.strip()
@@ -358,8 +359,11 @@ Call {STYLE_YELLOW}wat.globals{RESET} to inspect {STYLE_YELLOW}globals(){RESET} 
             text = _strip_color(text)
         print(text)
 
-    def _react_with(self, other: Any) -> None:
+    def _react_with(self, other: Any) -> Any:
+        ret = self._params.pop('ret')
         inspect(other, **self._params)
+        if ret:
+            return other
     
     def __call__(self, *args: Any, **kwargs: Any) -> Union['Wat', None]:
         if args:
@@ -392,6 +396,8 @@ Call {STYLE_YELLOW}wat.globals{RESET} to inspect {STYLE_YELLOW}globals(){RESET} 
             new_wat._params['nodocs'] = True
         elif name == 'all':
             new_wat._params['all'] = True
+        elif name == 'ret':
+            new_wat._params['ret'] = True
         elif name == 'locals':
             return inspect(_build_locals_object())
         elif name == 'globals':


### PR DESCRIPTION
I really like the project so far! I thought it could be nice if wat was able to return the object is was passed so that it could be used to inspect objects within expressions without affecting the result. This PR implements a `.ret` modifier that returns the inspected object e.g.

```python
>>> from wat import wat
>>> def a(x): return x * 2
... 
>>> def b(y): return y + 10
... 
>>> def c(z): return z**2
... 
>>> a(b(c(5)))
70
>>> a(wat.short.ret / b(c(5)))
────
value: 35
type: int
────
70
>>> 
```
Let me know what you think! If its something you'd be interested in I could add some test cases to the PR.