### PR TITLE
Callable import wat

### DIFF
--- a/wat/__init__.py
+++ b/wat/__init__.py
@@ -1,10 +1,8 @@
+import sys
+
 from .inspection.inspection import wat
 
 from .version import __version__
 
-name = "wat"
-
-__all__ = [
-    'wat',
-    '__version__',
-]
+sys.modules[__name__] = wat
+wat.__version__ = __version__


### PR DESCRIPTION
Replaces the `wat` module with the `wat.wat` object, allowing shortening `from wat import wat` to `import wat`.
