### PR TITLE
feat: Show length of all objects supporting len protocol

### DIFF
--- a/tests/inspection/test_inspect.py
+++ b/tests/inspection/test_inspect.py
@@ -352,3 +352,16 @@ Private attributes:
 def test_backwards_wat_wat_import():
     from wat import wat
     assert wat.ret / 'foo' == 'foo'
+
+
+def test_inspect_overriden_len():
+    class Foo:
+        def __len__(self):
+            return 4
+
+    output = inspect_format(Foo())
+    assert_multiline_match(output, r'''
+value: <test_inspect\.test_inspect_overriden_len\.<locals>\.Foo object at .*>
+type: test_inspect\.Foo
+len: 4
+''')

--- a/wat/inspection/inspection.py
+++ b/wat/inspection/inspection.py
@@ -69,7 +69,8 @@ def inspect_format(
         output.append(f'{STYLE_BRIGHT_BLUE}parents:{RESET} {parents}')
 
 
-    if isinstance(obj, (list, dict, str, bytes, bytearray, tuple, set, frozenset, range)):
+    len_attr = getattr(obj, '__len__', None)
+    if callable(len_attr):
         output.append(f'{STYLE_BRIGHT_BLUE}len:{RESET} {_format_value(len(obj))}')
  
     if callable(obj):


### PR DESCRIPTION
`len` internally tries calling an object's `__len__` function. Extend support
for showing the length of any object which `len` supports.
