### PR TITLE
feat: add env variable to disable color output

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,3 +224,6 @@ wat.locals
 ```python
 wat.globals
 ```
+
+### Environment variables
+Automatically disable color in output by setting `PYTHON_WAT_DISABLECOLOR="true"`

--- a/wat/inspection/inspection.py
+++ b/wat/inspection/inspection.py
@@ -95,11 +95,12 @@ def inspect_format(
 
     if sys.stdout.isatty():  # horizontal bar
         terminal_width = os.get_terminal_size().columns
-        output.insert(0, STYLE_BLUE + '─' * terminal_width + RESET)
-        output.append(STYLE_BLUE + '─' * terminal_width + RESET)
+        if not ("PYTHON_WAT_DISABLECOLOR" in os.environ and os.environ["PYTHON_WAT_DISABLECOLOR"] == 'true'):
+            output.insert(0, STYLE_BLUE + '─' * terminal_width + RESET)
+            output.append(STYLE_BLUE + '─' * terminal_width + RESET)
 
     text = '\n'.join(line for line in output if line is not None)
-    if not sys.stdout.isatty() or ("PYTHON_WAT_DISABLECOLOR" in os.environ and os.environ["PYTHON_WAT_DISABLECOLOR"] == 'true'):
+    if (not sys.stdout.isatty()) or ("PYTHON_WAT_DISABLECOLOR" in os.environ and os.environ["PYTHON_WAT_DISABLECOLOR"] == 'true'):
         text = _strip_color(text)
     return text
 
@@ -345,7 +346,7 @@ Try {STYLE_YELLOW}wat / object{RESET} or {STYLE_YELLOW}wat.modifiers / object{RE
 Call {STYLE_YELLOW}wat.locals{RESET} or {STYLE_YELLOW}wat(){RESET} to inspect {STYLE_YELLOW}locals(){RESET} variables.
 Call {STYLE_YELLOW}wat.globals{RESET} to inspect {STYLE_YELLOW}globals(){RESET} variables.
 """.strip()
-        if not sys.stdout.isatty():
+        if (not sys.stdout.isatty()) or ("PYTHON_WAT_DISABLECOLOR" in os.environ and os.environ["PYTHON_WAT_DISABLECOLOR"] == 'true'):
             text = _strip_color(text)
         print(text)
 

--- a/wat/inspection/inspection.py
+++ b/wat/inspection/inspection.py
@@ -99,7 +99,7 @@ def inspect_format(
         output.append(STYLE_BLUE + '─' * terminal_width + RESET)
 
     text = '\n'.join(line for line in output if line is not None)
-    if not sys.stdout.isatty():
+    if not sys.stdout.isatty() or ("PYTHON_WAT_DISABLECOLOR" in os.environ and os.environ["PYTHON_WAT_DISABLECOLOR"] == 'true'):
         text = _strip_color(text)
     return text
 


### PR DESCRIPTION
Simply adding an env variable to disable the colors in output, as it can be an issue with some terminal themes (in my case using Kitty): https://github.com/igrek51/wat/issues/18#issuecomment-2255466450
